### PR TITLE
React Native compatibility – add a Buffer module?

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "babel-relay-plugin": "0.9.3",
     "bluebird": "3.4.6",
+    "buffer": "^5.0.6",
     "commander": "2.9.0",
     "compression": "1.6.2",
     "cookie-parser": "1.4.3",
@@ -83,10 +84,10 @@
   },
   "peerDependencies": {
     "babel-core": "^6.0.0",
+    "babel-plugin-react-intl": "^2.2.0",
     "babel-preset-es2015": "^6.0.0",
-    "babel-preset-stage-0": "^6.0.0",
     "babel-preset-react": "^6.0.0",
-    "babel-plugin-react-intl": "^2.2.0"
+    "babel-preset-stage-0": "^6.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/common/base64.js
+++ b/src/common/base64.js
@@ -1,8 +1,10 @@
 // @flow
 
+const Buffer = require('buffer').Buffer;
+
 const utf8ToBase64 = (str: string): string =>
-  new Buffer(str, 'utf8').toString('base64');
+  Buffer.from(str, 'utf8').toString('base64');
 const base64ToUtf8 = (str: string): string =>
-  new Buffer(str, 'base64').toString('utf8');
+  Buffer.from(str, 'base64').toString('utf8');
 
 export { utf8ToBase64, base64ToUtf8 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,6 +1223,13 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.6.tgz#2ea669f7eec0b6eda05b08f8b5ff661b28573588"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"


### PR DESCRIPTION
I was adding Mady to a fresh React Native project, and ran into an issue: Seems like React Native does not handle the built-in `Buffer` module in Node, which seems a bit odd.

I tried patching it with a npm package of the Buffer module and that works, though I have a feeling this is not the right way to go about it … 

Here's the source of a sample expo.io project I used to verify the patch:
https://github.com/bjrn/rn-mady-example

And the error screen I was getting in the iOS simulator:
![image](https://cloud.githubusercontent.com/assets/151166/25576812/f5e2859c-2e61-11e7-96aa-016614ac6f4b.png)
