### PR TITLE
Feature/use reactid as context

### DIFF
--- a/src/client/components/070-details.js
+++ b/src/client/components/070-details.js
@@ -82,7 +82,11 @@ class Details extends React.Component {
       : null;
     return (
       <div>
-        {description && <div>{description}</div>}
+        {description &&
+          <div style={style.description}>
+            <span style={style.descriptionTitle}>{_t('msgDetailsView_Description:')}</span>
+            {description}
+          </div>}
         {_t('msgDetailsView_Used since')} {since}{until}
         {elSources}
       </div>
@@ -119,6 +123,13 @@ const style = {
   srcList: {
     marginTop: 0,
   },
+  description: {
+    marginBottom: 10,
+  },
+  descriptionTitle: {
+    fontWeight: 900,
+    marginRight: 10,
+  }
 };
 
 // ==========================================

--- a/src/server/parseSources.js
+++ b/src/server/parseSources.js
@@ -119,8 +119,13 @@ const parseReactIntl = (
     const { messages } = babelCore.transform(fileContents, babelConfig).metadata['react-intl'];
     if (messages) {
       messages.forEach((message) => {
-        const { defaultMessage: utf8, description, id: reactIntlId } = message;
-        addMessageToKeys(keys, utf8, filePath, { reactIntlId, description });
+        const { defaultMessage: utf8, description, id: reactIntlId, start, end } = message;
+        addMessageToKeys(keys, utf8, filePath, {
+          reactIntlId,
+          description,
+          start,
+          end,
+        });
       });
     }
   } catch (err2) {
@@ -155,7 +160,14 @@ const addMessageToKeys = (
     unusedSince: null,
     sources: [],
   };
-  keys[base64].sources.push(slash(filePath));
+  // TODO: if we have start/end, add that to the filePath in a nicer way
+  // maybe making the sources array an object: { file, start, end }
+  let sourceString = slash(filePath);
+  const { start, end } = extras;
+  if (start && end) {
+    sourceString += ` (${start.line}:${start.column}-${end.line}:${end.column})`;
+  }
+  keys[base64].sources.push(sourceString);
 };
 
 // ======================================================

--- a/src/server/parseSources.js
+++ b/src/server/parseSources.js
@@ -123,6 +123,7 @@ const parseReactIntl = (
         addMessageToKeys(keys, utf8, filePath, {
           reactIntlId,
           description,
+          context: reactIntlId,
           start,
           end,
         });


### PR DESCRIPTION
this PR adds some additional behaviour for react-intl messages:

- use the react-intl id as context (instead of having none)
- if babel extracted file and start/end lines/columns, add those to the sources string
- make the description easier to spot for translators (some margins + a hint in front)