### PR TITLE
Fix duplicate paths in keys.json on Windows

### DIFF
--- a/src/server/db.js
+++ b/src/server/db.js
@@ -4,6 +4,7 @@
 
 import path from 'path';
 import fs from 'fs-extra';
+import slash from 'slash';
 import { addDefaults, merge } from 'timm';
 import { mainStory, chalk } from 'storyboard';
 import uuid from 'uuid';
@@ -134,6 +135,7 @@ function saveConfig(options?: Object) {
 }
 
 const onFileChange = async (eventType, filePath) => {
+  filePath = slash(filePath)
   if (eventType === 'unlink') {
     onSrcFileDeleted(filePath, { save: true });
   } else if (eventType === 'add') {


### PR DESCRIPTION
Fixes additional failure cases where backslash paths were saved and duplicated on Windows in keys.json whe file change handler runs, example
```
    "sources": [
      "pages/me/login.vue",
      "pages\\me\\login.vue"
    ]
```

Aside: I've tested this locally using direct editing of build outputs. But for many reasons 'yarn build' currently fails on Windows, so I can't run the full test suite.
