### PR TITLE
Include all messages for the original language in the react-intl output

### DIFF
--- a/src/server/__tests__/collectReactIntlTranslations.test.js
+++ b/src/server/__tests__/collectReactIntlTranslations.test.js
@@ -58,4 +58,18 @@ describe('collectReactIntlTranslations', () => {
     });
     expect(result).toEqual({ reactIntlId3: 'Hello {NAME}!' });
   });
+
+  it('should include all keys with React Intl IDs, for the original lang', () => {
+    const result = collectReactIntlTranslations({
+      originalLang: 'en',
+      lang: 'en',
+      keys: KEYS_INCLUDING_SOME_WITH_BRACES,
+      translations: [],
+      story: mainStory,
+    });
+    expect(result).toEqual({
+      reactIntlId1: 'Hello there!',
+      reactIntlId3: 'Hello {NAME}!'
+    });
+  });
 });

--- a/src/server/collectReactIntlTranslations.js
+++ b/src/server/collectReactIntlTranslations.js
@@ -9,11 +9,13 @@ import type {
 } from '../common/types';
 
 export default function collectReactIntlTranslations({
+  originalLang,
   lang,
   keys,
   translations,
   story,
 }: {|
+  originalLang: string,
   lang: string,
   keys: MapOf<InternalKeyT>,
   translations: Array<InternalTranslationT>,
@@ -31,7 +33,7 @@ export default function collectReactIntlTranslations({
     const key = keys[keyId];
     const { reactIntlId } = key;
     if (!reactIntlId) return;
-    if (key.text.indexOf('{') >= 0) {
+    if (key.text.indexOf('{') >= 0 || lang === originalLang) {
       finalTranslations[reactIntlId] = key.text;
     }
   });

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -655,6 +655,7 @@ function compileTranslations({ story: baseStory }: { story?: StoryT } = {}) {
       if (_config.fReactIntlOutput) {
         const reactIntlLangPath = getReactIntlLangPath(lang);
         const reactIntlTranslations = collectReactIntlTranslations({
+          originalLang: _config.originalLang,
           lang,
           keys,
           translations,


### PR DESCRIPTION
First off, awesome project. It makes working with react-intl a lot easier, especially for small scale translations (in comparison to react-intl-translations-manager + serge + pootle).

When trying this library to build the message bundles for react-intl, I noticed the file for the original language only contained the default message when an interpolation was given.

I figured since the messages are the defaults and therefore already in the code one might one of two things;
* Not include the original lang in `config.langs` or disregard the outputted `<defaultLang>.reactIntl.json` file.
* Strip the default language from the react props during build, and load the translations for the original language in the same way as all the translated locales.

This PR shouldn't change behaviour for the first case, but it'll make the second case possible