### PR TITLE
Upgrade upath for node 9+ compatibility

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8995,8 +8995,8 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
The node stable build in https://github.com/guigrpa/mady/pull/19 was failing due to node 9+ being bumped to stable, this upgrades [the blocking dependency](https://github.com/anodynos/upath/commit/8c5f4e10376ed1cd4553d9432297d39a34410c69).

The coverage report at the end of the CI still hangs, I tried to upgrade those dependencies, but an error kept popping up (Error: Invalid file coverage object, missing keys, found:data). Being unfamiliar with coverage/nyc, I gave up on that part.